### PR TITLE
feat(rpc): Add optional RPC types

### DIFF
--- a/crates/mev-share-rpc-api/src/types.rs
+++ b/crates/mev-share-rpc-api/src/types.rs
@@ -12,22 +12,22 @@ pub struct SendBundleRequest {
     pub protocol_version: ProtocolVersion,
     /// Data used by block builders to check if the bundle should be considered for inclusion.
     #[serde(rename = "inclusion")]
-    pub inclusion_predicate: InclusionPredicate,
+    pub inclusion: Inclusion,
     /// The transactions to include in the bundle.
     #[serde(rename = "body")]
     pub bundle_body: Vec<BundleItem>,
     /// Requirements for the bundle to be included in the block. 
     #[serde(rename = "validity", skip_serializing_if = "Option::is_none")] 
-    pub validity_predicate: Option<ValidityPredicate>,
+    pub validity: Option<Validity>,
     /// Preferences on what data should be shared about the bundle and its transactions
     #[serde(rename = "privacy", skip_serializing_if = "Option::is_none")]
-    pub privacy_predicate: Option<PrivacyPredicate>,
+    pub privacy: Option<Privacy>,
 }
 
 /// Data used by block builders to check if the bundle should be considered for inclusion.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub struct InclusionPredicate {
+pub struct Inclusion {
     /// The first block the bundle is valid for.
     pub block: U64,
     /// The last block the bundle is valid for.
@@ -58,7 +58,7 @@ pub enum BundleItem {
 /// Requirements for the bundle to be included in the block.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub struct ValidityPredicate {
+pub struct Validity {
     /// Specifies the minimum percent of a given bundle's earnings to redistribute 
     /// for it to be included in a builder's block.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -94,7 +94,7 @@ pub struct RefundConfig {
 /// Preferences on what data should be shared about the bundle and its transactions
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
-pub struct PrivacyPredicate {
+pub struct Privacy {
     /// Hints on what data should be shared about the bundle and its transactions
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hints: Option<Vec<PrivacyHint>>,
@@ -151,13 +151,13 @@ impl SendBundleRequest {
     ) -> Self {
         Self {
             protocol_version,
-            inclusion_predicate: InclusionPredicate {
+            inclusion: Inclusion {
                 block: block_num,
                 max_block,
             },
             bundle_body,
-            validity_predicate: None,
-            privacy_predicate: None,
+            validity: None,
+            privacy: None,
         }
     }
 }
@@ -168,7 +168,7 @@ mod tests {
 
     use ethers_core::types::Bytes;
 
-    use crate::{types::SendBundleRequest, types::ProtocolVersion, InclusionPredicate, BundleItem, ValidityPredicate, RefundConfig, PrivacyPredicate, PrivacyHint};
+    use crate::{types::SendBundleRequest, types::ProtocolVersion, Inclusion, BundleItem, Validity, RefundConfig, Privacy, PrivacyHint};
 
     #[test]
     fn can_deserialize_simple() {
@@ -251,26 +251,26 @@ mod tests {
             can_revert: false,
         }];
 
-        let validity_predicate = ValidityPredicate {
+        let validity = Some(Validity {
             refund_config: Some(vec![RefundConfig {
                 address: "0x8EC1237b1E80A6adf191F40D4b7D095E21cdb18f".parse().unwrap(),
                 percent: 100,
             }]),
             ..Default::default()
-        };
-        let privacy_predicate = PrivacyPredicate {
+        });
+        let privacy = Some(Privacy {
             hints: Some(vec![PrivacyHint::Calldata]),
             ..Default::default()
-        };
+        });
         let bundle = SendBundleRequest {
             protocol_version: ProtocolVersion::V0_1,
-            inclusion_predicate: InclusionPredicate {
+            inclusion: Inclusion {
                 block: 1.into(),
                 max_block: None,
             },
             bundle_body,
-            validity_predicate: Some(validity_predicate),
-            privacy_predicate: Some(privacy_predicate),
+            validity,
+            privacy,
         };
         let expected = serde_json::from_str::<Vec<SendBundleRequest>>(str).unwrap();
         assert_eq!(bundle, expected[0]);

--- a/crates/mev-share-rpc-api/src/types.rs
+++ b/crates/mev-share-rpc-api/src/types.rs
@@ -40,8 +40,8 @@ pub struct InclusionPredicate {
 #[serde(untagged)]
 #[serde(rename_all = "camelCase")]
 pub enum BundleItem {
-    /// The hash of the transaction we are trying to backrun.
-    TxHash {
+    /// The hash of either a transaction or bundle we are trying to backrun.
+    Hash {
         /// Tx hash.
         hash: TxHash,
     },
@@ -53,14 +53,6 @@ pub enum BundleItem {
         /// If true, the transaction can revert without the bundle being considered invalid.
         can_revert: bool,
     },
-    /// A bundle to backrun.
-    Bundle {
-        /// Params for the bundle.
-        bundle: SendBundleRequest,
-    },
-    /// By specifying an empty object in the body array, searchers can specify if, and where, 
-    /// other transactions may be included with relation to their bundle.
-    AllowBackrun { }
 }
 
 /// Requirements for the bundle to be included in the block.

--- a/crates/mev-share-rpc-api/src/types.rs
+++ b/crates/mev-share-rpc-api/src/types.rs
@@ -409,4 +409,34 @@ mod tests {
         let expected = serde_json::from_str::<Vec<SendBundleRequest>>(str).unwrap();
         assert_eq!(bundle, expected[0]);
     }
+
+    #[test]
+    fn can_serialize_privacy_hint() {
+        let hint = PrivacyHint {
+            calldata: true,
+            contract_address: true,
+            logs: true,
+            function_selector: true,
+            hash: true,
+            tx_hash: true,
+        };
+        let expected = r#"["calldata","contract_address","logs","function_selector","hash","tx_hash"]"#;
+        let actual = serde_json::to_string(&hint).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn can_deserialize_privacy_hint() {
+        let hint = PrivacyHint {
+            calldata: true,
+            contract_address: false,
+            logs: true,
+            function_selector: false,
+            hash: true,
+            tx_hash: false,
+        };
+        let expected = r#"["calldata","logs","hash"]"#;
+        let actual: PrivacyHint = serde_json::from_str(expected).unwrap();
+        assert_eq!(actual, hint);
+    }
 }

--- a/crates/mev-share-rpc-api/src/types.rs
+++ b/crates/mev-share-rpc-api/src/types.rs
@@ -1,7 +1,9 @@
 //! MEV-share bundle type bindings
 
 use ethers_core::types::{Bytes, U64, TxHash, Address};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Deserializer};
+use serde::ser::{Serializer, SerializeSeq};
+
 
 /// A bundle of transactions to send to the matchmaker.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
@@ -97,29 +99,156 @@ pub struct RefundConfig {
 pub struct Privacy {
     /// Hints on what data should be shared about the bundle and its transactions
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub hints: Option<Vec<PrivacyHint>>,
+    pub hints: Option<PrivacyHint>,
     /// The addresses of the builders that should be allowed to see the bundle.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub builders: Option<Vec<Address>>,
 }
 
 /// Hints on what data should be shared about the bundle and its transactions
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-#[serde(rename_all = "snake_case")]
-pub enum PrivacyHint {
-    /// The calldata of the transaction.
-    Calldata,
-    /// The address of the contract the transaction is calling.
-    ContractAddress,
-    /// The logs emitted by the transaction.
-    Logs,
-    /// The 4-byte function selector of the transaction.
-    FunctionSelector,
-    /// The hash of the transaction.
-    Hash,
+#[derive(Clone, Debug, PartialEq)]
+#[derive(Default)]
+pub struct PrivacyHint {
+    /// The calldata of the bundle's transactions should be shared.
+    pub calldata: bool,
+    /// The address of the bundle's transactions should be shared.
+    pub contract_address: bool,
+    /// The logs of the bundle's transactions should be shared.
+    pub logs: bool,
+    /// The function selector of the bundle's transactions should be shared.
+    pub function_selector: bool,
+    /// The hash of the bundle's transactions should be shared.
+    pub hash: bool,
+    /// The hash of the bundle should be shared.
+    pub tx_hash: bool,
 }
 
 
+
+#[allow(missing_docs)]
+impl PrivacyHint {
+
+    pub fn with_calldata(mut self) -> Self {
+        self.calldata = true;
+        self
+    }
+
+    pub fn with_contract_address(mut self) -> Self {
+        self.contract_address = true;
+        self
+    }
+
+    pub fn with_logs(mut self) -> Self {
+        self.logs = true;
+        self
+    }
+
+    pub fn with_function_selector(mut self) -> Self {
+        self.function_selector = true;
+        self
+    }
+
+    pub fn with_hash(mut self) -> Self {
+        self.hash = true;
+        self
+    }
+
+    pub fn with_tx_hash(mut self) -> Self {
+        self.tx_hash = true;
+        self
+    }
+
+    pub fn has_calldata(&self) -> bool {
+        self.calldata
+    }
+
+    pub fn has_contract_address(&self) -> bool {
+        self.contract_address
+    }
+
+    pub fn has_logs(&self) -> bool {
+        self.logs
+    }
+
+    pub fn has_function_selector(&self) -> bool {
+        self.function_selector
+    }
+
+    pub fn has_hash(&self) -> bool {
+        self.hash
+    }
+
+    pub fn has_tx_hash(&self) -> bool {
+        self.tx_hash
+    }
+
+    fn num_hints(&self) -> usize {
+        let mut num_hints = 0;
+        if self.calldata {
+            num_hints += 1;
+        }
+        if self.contract_address {
+            num_hints += 1;
+        }
+        if self.logs {
+            num_hints += 1;
+        }
+        if self.function_selector {
+            num_hints += 1;
+        }
+        if self.hash {
+            num_hints += 1;
+        }
+        if self.tx_hash {
+            num_hints += 1;
+        }
+        num_hints
+    }
+}
+
+impl Serialize for PrivacyHint {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut seq = serializer.serialize_seq(Some(self.num_hints()))?;
+        if self.calldata {
+            seq.serialize_element("calldata")?;
+        }
+        if self.contract_address {
+            seq.serialize_element("contract_address")?;
+        }
+        if self.logs {
+            seq.serialize_element("logs")?;
+        }
+        if self.function_selector {
+            seq.serialize_element("function_selector")?;
+        }
+        if self.hash {
+            seq.serialize_element("hash")?;
+        }
+        if self.tx_hash {
+            seq.serialize_element("tx_hash")?;
+        }
+        seq.end()
+    }
+}
+
+impl<'de> Deserialize<'de> for PrivacyHint {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let hints = Vec::<String>::deserialize(deserializer)?;
+        let mut privacy_hint = PrivacyHint::default();
+        for hint in hints {
+            match hint.as_str() {
+                "calldata" => privacy_hint.calldata = true,
+                "contract_address" => privacy_hint.contract_address = true,
+                "logs" => privacy_hint.logs = true,
+                "function_selector" => privacy_hint.function_selector = true,
+                "hash" => privacy_hint.hash = true,
+                "tx_hash" => privacy_hint.tx_hash = true,
+                _ => return Err(serde::de::Error::custom("invalid privacy hint")),
+            }
+        }
+        Ok(privacy_hint)
+    }
+}
 
 /// Response from the matchmaker after sending a bundle.
 #[derive(Deserialize, Debug, Serialize, Clone, PartialEq)]
@@ -258,10 +387,15 @@ mod tests {
             }]),
             ..Default::default()
         });
+
         let privacy = Some(Privacy {
-            hints: Some(vec![PrivacyHint::Calldata]),
+            hints: Some(PrivacyHint {
+                calldata: true,
+                ..Default::default()
+            }),
             ..Default::default()
         });
+       
         let bundle = SendBundleRequest {
             protocol_version: ProtocolVersion::V0_1,
             inclusion: Inclusion {


### PR DESCRIPTION
Adding optional RPC types (validity predicates & privacy predicates), as well as new `BundleItem` variations for bundle composition (`Bundle` and `AllowBackrun`) 

solves https://github.com/paradigmxyz/mev-share-rs/issues/8#issue-1786887942