### PR TITLE
feat: flashbots style auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "aes"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac1f845298e95f983ff1944b728ae08b8cebab80d684f0a832ed0fc74dfa27e2"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,10 +137,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bech32"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
+
+[[package]]
 name = "beef"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
 dependencies = [
  "serde",
 ]
@@ -142,12 +168,22 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitvec"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
+dependencies = [
+ "either",
+ "radium 0.3.0",
+]
+
+[[package]]
+name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
- "radium",
+ "radium 0.7.0",
  "tap",
  "wyz",
 ]
@@ -168,6 +204,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "bs58"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+dependencies = [
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -227,6 +272,72 @@ checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "num-traits",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "coins-bip32"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b30a84aab436fcb256a2ab3c80663d8aec686e6bae12827bb05fef3e1e439c9f"
+dependencies = [
+ "bincode",
+ "bs58",
+ "coins-core",
+ "digest 0.10.7",
+ "getrandom 0.2.10",
+ "hmac",
+ "k256",
+ "lazy_static",
+ "serde",
+ "sha2 0.10.7",
+ "thiserror",
+]
+
+[[package]]
+name = "coins-bip39"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84f4d04ee18e58356accd644896aeb2094ddeafb6a713e056cef0c0a8e468c15"
+dependencies = [
+ "bitvec 0.17.4",
+ "coins-bip32",
+ "getrandom 0.2.10",
+ "hmac",
+ "once_cell",
+ "pbkdf2 0.12.1",
+ "rand 0.8.5",
+ "sha2 0.10.7",
+ "thiserror",
+]
+
+[[package]]
+name = "coins-core"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b949a1c63fb7eb591eb7ba438746326aedf0ae843e51ec92ba6bec5bb382c4f"
+dependencies = [
+ "base64 0.21.2",
+ "bech32",
+ "bs58",
+ "digest 0.10.7",
+ "generic-array",
+ "hex",
+ "ripemd",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.7",
+ "sha3",
+ "thiserror",
 ]
 
 [[package]]
@@ -307,6 +418,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "der"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +483,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -415,6 +541,28 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "eth-keystore"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
+dependencies = [
+ "aes",
+ "ctr",
+ "digest 0.10.7",
+ "hex",
+ "hmac",
+ "pbkdf2 0.11.0",
+ "rand 0.8.5",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "sha2 0.10.7",
+ "sha3",
+ "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -493,6 +641,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-signers"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02c4b7e15f212fa7cc2e1251868320221d4ff77a3d48068e69f47ce1c491df2d"
+dependencies = [
+ "async-trait",
+ "coins-bip32",
+ "coins-bip39",
+ "elliptic-curve",
+ "eth-keystore",
+ "ethers-core",
+ "hex",
+ "rand 0.8.5",
+ "sha2 0.10.7",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,11 +669,14 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 name = "examples"
 version = "0.0.0"
 dependencies = [
+ "ethers-core",
+ "ethers-signers",
  "futures-util",
  "jsonrpsee",
  "mev-share-rpc-api",
  "mev-share-sse",
  "tokio",
+ "tower",
  "tracing-subscriber",
 ]
 
@@ -708,8 +878,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1029,6 +1201,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
 
 [[package]]
+name = "inout"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1235,7 +1416,8 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "once_cell",
- "sha2",
+ "sha2 0.10.7",
+ "signature",
 ]
 
 [[package]]
@@ -1301,9 +1483,15 @@ name = "mev-share-rpc-api"
 version = "0.1.0"
 dependencies = [
  "ethers-core",
+ "ethers-signers",
+ "futures-util",
+ "http",
+ "hyper",
  "jsonrpsee",
  "serde",
  "serde_json",
+ "tokio",
+ "tower",
 ]
 
 [[package]]
@@ -1488,7 +1676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2287753623c76f953acd29d15d8100bcab84d29db78fb6f352adb3c53e83b967"
 dependencies = [
  "arrayvec",
- "bitvec",
+ "bitvec 1.0.1",
  "byte-slice-cast",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
@@ -1534,6 +1722,25 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0ca0b5a68607598bf3bad68f32227a8164f6254833f84eafaac409cd6746c31"
+dependencies = [
+ "digest 0.10.7",
+ "hmac",
 ]
 
 [[package]]
@@ -1661,6 +1868,12 @@ checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
 
 [[package]]
 name = "radium"
@@ -1845,6 +2058,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,6 +2170,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "scale-info"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,6 +2216,18 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scrypt"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
+dependencies = [
+ "hmac",
+ "pbkdf2 0.11.0",
+ "salsa20",
+ "sha2 0.10.7",
+]
 
 [[package]]
 name = "sct"
@@ -2108,6 +2351,19 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
+name = "sha2"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
@@ -2134,6 +2390,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2233,9 +2498,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -2344,7 +2609,9 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.48.0",
@@ -2565,6 +2832,16 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.10",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ repository ="https://github.com/mattsse/mev-share-rs"
 [workspace.dependencies]
 ## eth
 ethers-core = { version = "2.0", default-features = false }
+ethers-signers = "2.0.7"
 
 ## misc
 serde_json = "1.0"

--- a/crates/mev-share-rpc-api/Cargo.toml
+++ b/crates/mev-share-rpc-api/Cargo.toml
@@ -14,13 +14,21 @@ MEV-share RPC API trait definitions
 [dependencies]
 ## eth
 ethers-core.workspace = true
+ethers-signers = "2.0.7"
 
 ## misc
 jsonrpsee = { version = "0.18", features = ["server", "macros"] }
 serde = { version = "1.0", features = ["derive"] }
+http = "0.2.9"
+hyper = { version = "0.14.26", features = ["stream"] }
+tower = "0.4.13"
+futures-util = "0.3.28"
+
 
 [dev-dependencies]
 serde_json.workspace = true
+tokio = { version = "1.18", features = ["full"] }
+# tokio-test = "0.4.2"
 
 
 [features]

--- a/crates/mev-share-rpc-api/Cargo.toml
+++ b/crates/mev-share-rpc-api/Cargo.toml
@@ -28,7 +28,6 @@ futures-util = "0.3.28"
 [dev-dependencies]
 serde_json.workspace = true
 tokio = { version = "1.18", features = ["full"] }
-# tokio-test = "0.4.2"
 
 
 [features]

--- a/crates/mev-share-rpc-api/Cargo.toml
+++ b/crates/mev-share-rpc-api/Cargo.toml
@@ -14,7 +14,7 @@ MEV-share RPC API trait definitions
 [dependencies]
 ## eth
 ethers-core.workspace = true
-ethers-signers = "2.0.7"
+ethers-signers.workspace = true
 
 ## misc
 jsonrpsee = { version = "0.18", features = ["server", "macros"] }

--- a/crates/mev-share-rpc-api/src/auth.rs
+++ b/crates/mev-share-rpc-api/src/auth.rs
@@ -39,7 +39,7 @@ impl<S: Clone, I> Layer<I> for FlashbotsSignerLayer<S> {
     }
 }
 
-/// Middleware that adds a request header with a signed payload.
+/// Middleware that signs the request body and adds the signature to the x-flashbots-signature header.
 /// For more info, see https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint#authentication
 #[derive(Clone)]
 pub struct FlashbotsSigner<S, I> {
@@ -97,7 +97,7 @@ where
                 .await?;
 
             let header_val =
-                HeaderValue::from_str(&format!("{:?}:0x{}", signer.address(), signature)).unwrap();
+                HeaderValue::from_str(&format!("{:?}:0x{}", signer.address(), signature)).expect("Header contains invalid characters");
             parts.headers.insert(FLASHBOTS_HEADER, header_val);
 
             let request = Request::from_parts(parts, Body::from(body_bytes.clone()));

--- a/crates/mev-share-rpc-api/src/auth.rs
+++ b/crates/mev-share-rpc-api/src/auth.rs
@@ -93,7 +93,7 @@ where
 
             // sign request body and insert header
             let signature = signer
-                .sign_message(format!("0x{:x}", H256::from(keccak256(body_bytes.clone()))))
+                .sign_message(format!("0x{:x}", H256::from(keccak256(body_bytes.as_ref()))))
                 .await?;
 
             let header_val =

--- a/crates/mev-share-rpc-api/src/auth.rs
+++ b/crates/mev-share-rpc-api/src/auth.rs
@@ -39,8 +39,8 @@ impl<S: Clone, I> Layer<I> for FlashbotsSignerLayer<S> {
     }
 }
 
-/// Middleware that signs the request body and adds the signature to the x-flashbots-signature header.
-/// For more info, see <https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint#authentication>
+/// Middleware that signs the request body and adds the signature to the x-flashbots-signature
+/// header. For more info, see <https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint#authentication>
 #[derive(Clone)]
 pub struct FlashbotsSigner<S, I> {
     signer: S,
@@ -70,11 +70,11 @@ where
 
         let (mut parts, body) = request.into_parts();
 
-        // if method is not POST, return an error. 
+        // if method is not POST, return an error.
         if parts.method != http::Method::POST {
-           return Box::pin(async move {
+            return Box::pin(async move {
                 Err(format!("Invalid method: {}", parts.method.as_str()).into())
-            }) 
+            })
         }
 
         // if content-type is not json, or signature already exists, just pass through the request
@@ -102,7 +102,8 @@ where
                 .await?;
 
             let header_val =
-                HeaderValue::from_str(&format!("{:?}:0x{}", signer.address(), signature)).expect("Header contains invalid characters");
+                HeaderValue::from_str(&format!("{:?}:0x{}", signer.address(), signature))
+                    .expect("Header contains invalid characters");
             parts.headers.insert(FLASHBOTS_HEADER, header_val);
 
             let request = Request::from_parts(parts, Body::from(body_bytes.clone()));

--- a/crates/mev-share-rpc-api/src/auth.rs
+++ b/crates/mev-share-rpc-api/src/auth.rs
@@ -1,0 +1,148 @@
+//! A layer responsible for implementing flashbots-style authentication
+//! by signing the request body with a private key and adding the signature
+//! to the request headers.
+
+use std::{
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use ethers_core::{types::H256, utils::keccak256};
+use ethers_signers::Signer;
+use futures_util::future::BoxFuture;
+
+use http::{header::HeaderValue, HeaderName, Request};
+use hyper::Body;
+
+use tower::{Layer, Service};
+
+/// Layer that applies [`FlashbotsSigner`] which adds a request header with a signed payload.
+#[derive(Clone)]
+pub struct FlashbotsSignerLayer<S> {
+    signer: Arc<S>,
+}
+
+impl<S> FlashbotsSignerLayer<S> {
+    /// Creates a new [`FlashbotsSignerLayer`] with the given signer.
+    pub fn new(signer: Arc<S>) -> Self {
+        FlashbotsSignerLayer { signer }
+    }
+}
+
+impl<S: Clone, I> Layer<I> for FlashbotsSignerLayer<S> {
+    type Service = FlashbotsSigner<S, I>;
+
+    fn layer(&self, inner: I) -> Self::Service {
+        FlashbotsSigner {
+            signer: self.signer.clone(),
+            inner,
+        }
+    }
+}
+
+/// Middleware that adds a request header with a signed payload.
+/// For more info, see https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint#authentication
+#[derive(Clone)]
+pub struct FlashbotsSigner<S, I> {
+    signer: Arc<S>,
+    inner: I,
+}
+
+impl<S, I> Service<Request<Body>> for FlashbotsSigner<S, I>
+where
+    I: Service<Request<Body>> + Clone + Send + 'static,
+    I::Future: Send,
+    S: Signer + Clone + Send + 'static,
+{
+    type Response = I::Response;
+    type Error = I::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        let clone = self.inner.clone();
+        // wait for service to be ready
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+        let signer = self.signer.clone();
+
+        let (mut parts, body) = request.into_parts();
+
+        Box::pin(async move {
+            let body_bytes = hyper::body::to_bytes(body).await.unwrap();
+
+            // sign request body and insert header
+            let signature = signer
+                .sign_message(format!("0x{:x}", H256::from(keccak256(body_bytes.clone()))))
+                .await
+                .unwrap();
+
+            let header_name = HeaderName::from_static("x-flashbots-signature");
+            let header_val =
+                HeaderValue::from_str(&format!("{:?}:0x{}", signer.address(), signature)).unwrap();
+            parts.headers.insert(header_name, header_val);
+
+            let request = Request::from_parts(parts, Body::from(body_bytes.clone()));
+
+            inner.call(request).await
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ethers_core::rand::thread_rng;
+    use ethers_signers::LocalWallet;
+    use http::Response;
+    use hyper::Body;
+    use std::convert::Infallible;
+    use tower::{service_fn, ServiceExt};
+
+    #[tokio::test]
+    async fn test_signature() {
+        let fb_signer =  Arc::new(LocalWallet::new(&mut thread_rng()));
+
+        // mock service that returns the request headers
+        let svc = FlashbotsSigner {
+            signer: fb_signer.clone(),
+            inner: service_fn(|_req: Request<Body>| async {
+                let (parts, _) = _req.into_parts();
+
+                let mut res = Response::builder();
+                for (k, v) in parts.headers.iter() {
+                    res = res.header(k, v);
+                }
+                let res = res.body(Body::empty()).unwrap();
+                Ok::<_, Infallible>(res)
+            }),
+        };
+
+        // generate set of bytes for the payload
+        let bytes = vec![1u8; 32];
+
+        let res = svc
+            .oneshot(Request::new(Body::from(bytes.clone())))
+            .await
+            .unwrap();
+
+        let header = res.headers().get("x-flashbots-signature").unwrap();
+        let header = header.to_str().unwrap();
+        let header = header.split(":0x").collect::<Vec<_>>();
+        let header_address = header[0];
+        let header_signature = header[1];
+
+        let signer_address = format!("{:?}", fb_signer.address());
+        let expected_signature = fb_signer
+            .sign_message(format!("0x{:x}", H256::from(keccak256(bytes.clone()))))
+            .await
+            .unwrap()
+            .to_string();
+
+        // verify that the header contains expected address and signature
+        assert_eq!(header_address, signer_address);
+        assert_eq!(header_signature, expected_signature);
+    }
+}

--- a/crates/mev-share-rpc-api/src/auth.rs
+++ b/crates/mev-share-rpc-api/src/auth.rs
@@ -40,7 +40,7 @@ impl<S: Clone, I> Layer<I> for FlashbotsSignerLayer<S> {
 }
 
 /// Middleware that signs the request body and adds the signature to the x-flashbots-signature header.
-/// For more info, see https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint#authentication
+/// For more info, see <https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint#authentication>
 #[derive(Clone)]
 pub struct FlashbotsSigner<S, I> {
     signer: S,

--- a/crates/mev-share-rpc-api/src/eth.rs
+++ b/crates/mev-share-rpc-api/src/eth.rs
@@ -12,7 +12,8 @@ pub trait EthBundleApi {
     #[method(name = "sendBundle")]
     async fn send_bundle(&self, request: ()) -> RpcResult<()>;
 
-    /// `eth_callBundle` can be used to simulate a bundle against a specific block number, including simulating a bundle at the top of the next block.
+    /// `eth_callBundle` can be used to simulate a bundle against a specific block number, including
+    /// simulating a bundle at the top of the next block.
     #[method(name = "callBundle")]
     async fn call_bundle(&self, request: ()) -> RpcResult<()>;
 
@@ -24,9 +25,11 @@ pub trait EthBundleApi {
     #[method(name = "sendPrivateTransaction")]
     async fn send_private_transaction(&self, request: ()) -> RpcResult<()>;
 
-    /// The `eth_cancelPrivateTransaction` method stops private transactions from being submitted for future blocks.
+    /// The `eth_cancelPrivateTransaction` method stops private transactions from being submitted
+    /// for future blocks.
     ///
-    /// A transaction can only be cancelled if the request is signed by the same key as the eth_sendPrivateTransaction call submitting the transaction in first place.
+    /// A transaction can only be cancelled if the request is signed by the same key as the
+    /// eth_sendPrivateTransaction call submitting the transaction in first place.
     #[method(name = "cancelPrivateTransaction")]
     async fn cancel_private_transaction(&self, request: ()) -> RpcResult<()>;
 }

--- a/crates/mev-share-rpc-api/src/lib.rs
+++ b/crates/mev-share-rpc-api/src/lib.rs
@@ -13,7 +13,7 @@ mod mev;
 /// `eth` namespace extension for bundles
 mod eth;
 
-/// type bindings 
+/// type bindings
 mod types;
 pub use types::*;
 
@@ -28,8 +28,7 @@ pub use servers::*;
 #[cfg(feature = "server")]
 #[doc(hidden)]
 pub mod servers {
-    pub use crate::mev::MevApiServer;
-    pub use crate::eth::EthBundleApiServer;
+    pub use crate::{eth::EthBundleApiServer, mev::MevApiServer};
 }
 
 /// re-export of all client traits
@@ -40,7 +39,5 @@ pub use clients::*;
 #[cfg(feature = "client")]
 #[doc(hidden)]
 pub mod clients {
-    pub use crate::mev::MevApiClient;
-    pub use crate::eth::EthBundleApiClient;
-    pub use crate::auth::FlashbotsSignerLayer;
+    pub use crate::{auth::FlashbotsSignerLayer, eth::EthBundleApiClient, mev::MevApiClient};
 }

--- a/crates/mev-share-rpc-api/src/lib.rs
+++ b/crates/mev-share-rpc-api/src/lib.rs
@@ -14,6 +14,10 @@ mod mev;
 mod types;
 pub use types::*;
 
+/// flashbots-style auth 
+mod auth;
+pub use auth::*;
+
 /// re-export of all server traits
 #[cfg(feature = "server")]
 pub use servers::*;

--- a/crates/mev-share-rpc-api/src/lib.rs
+++ b/crates/mev-share-rpc-api/src/lib.rs
@@ -19,7 +19,6 @@ pub use types::*;
 
 /// flashbots-style auth
 mod auth;
-pub use auth::*;
 
 /// re-export of all server traits
 #[cfg(feature = "server")]
@@ -43,4 +42,5 @@ pub use clients::*;
 pub mod clients {
     pub use crate::mev::MevApiClient;
     pub use crate::eth::EthBundleApiClient;
+    pub use crate::auth::FlashbotsSignerLayer;
 }

--- a/crates/mev-share-rpc-api/src/lib.rs
+++ b/crates/mev-share-rpc-api/src/lib.rs
@@ -10,11 +10,11 @@
 /// `mev` namespace
 mod mev;
 
-/// type bindings 
+/// type bindings
 mod types;
 pub use types::*;
 
-/// flashbots-style auth 
+/// flashbots-style auth
 mod auth;
 pub use auth::*;
 

--- a/crates/mev-share-rpc-api/src/types.rs
+++ b/crates/mev-share-rpc-api/src/types.rs
@@ -1,9 +1,10 @@
 //! MEV-share bundle type bindings
 
-use ethers_core::types::{Bytes, U64, TxHash, Address};
-use serde::{Deserialize, Serialize, Deserializer};
-use serde::ser::{Serializer, SerializeSeq};
-
+use ethers_core::types::{Address, Bytes, TxHash, U64};
+use serde::{
+    ser::{SerializeSeq, Serializer},
+    Deserialize, Deserializer, Serialize,
+};
 
 /// A bundle of transactions to send to the matchmaker.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
@@ -18,8 +19,8 @@ pub struct SendBundleRequest {
     /// The transactions to include in the bundle.
     #[serde(rename = "body")]
     pub bundle_body: Vec<BundleItem>,
-    /// Requirements for the bundle to be included in the block. 
-    #[serde(rename = "validity", skip_serializing_if = "Option::is_none")] 
+    /// Requirements for the bundle to be included in the block.
+    #[serde(rename = "validity", skip_serializing_if = "Option::is_none")]
     pub validity: Option<Validity>,
     /// Preferences on what data should be shared about the bundle and its transactions
     #[serde(rename = "privacy", skip_serializing_if = "Option::is_none")]
@@ -61,11 +62,11 @@ pub enum BundleItem {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub struct Validity {
-    /// Specifies the minimum percent of a given bundle's earnings to redistribute 
+    /// Specifies the minimum percent of a given bundle's earnings to redistribute
     /// for it to be included in a builder's block.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub refund: Option<Vec<Refund>>,
-    /// Specifies what addresses should receive what percent of the overall refund for this bundle, 
+    /// Specifies what addresses should receive what percent of the overall refund for this bundle,
     /// if it is enveloped by another bundle (eg. a searcher backrun).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub refund_config: Option<Vec<RefundConfig>>,
@@ -106,8 +107,7 @@ pub struct Privacy {
 }
 
 /// Hints on what data should be shared about the bundle and its transactions
-#[derive(Clone, Debug, PartialEq)]
-#[derive(Default)]
+#[derive(Clone, Debug, PartialEq, Default)]
 pub struct PrivacyHint {
     /// The calldata of the bundle's transactions should be shared.
     pub calldata: bool,
@@ -123,11 +123,8 @@ pub struct PrivacyHint {
     pub tx_hash: bool,
 }
 
-
-
 #[allow(missing_docs)]
 impl PrivacyHint {
-
     pub fn with_calldata(mut self) -> Self {
         self.calldata = true;
         self
@@ -280,10 +277,7 @@ impl SendBundleRequest {
     ) -> Self {
         Self {
             protocol_version,
-            inclusion: Inclusion {
-                block: block_num,
-                max_block,
-            },
+            inclusion: Inclusion { block: block_num, max_block },
             bundle_body,
             validity: None,
             privacy: None,
@@ -297,7 +291,10 @@ mod tests {
 
     use ethers_core::types::Bytes;
 
-    use crate::{types::SendBundleRequest, types::ProtocolVersion, Inclusion, BundleItem, Validity, RefundConfig, Privacy, PrivacyHint};
+    use crate::{
+        types::{ProtocolVersion, SendBundleRequest},
+        BundleItem, Inclusion, Privacy, PrivacyHint, RefundConfig, Validity,
+    };
 
     #[test]
     fn can_deserialize_simple() {
@@ -389,19 +386,13 @@ mod tests {
         });
 
         let privacy = Some(Privacy {
-            hints: Some(PrivacyHint {
-                calldata: true,
-                ..Default::default()
-            }),
+            hints: Some(PrivacyHint { calldata: true, ..Default::default() }),
             ..Default::default()
         });
-       
+
         let bundle = SendBundleRequest {
             protocol_version: ProtocolVersion::V0_1,
-            inclusion: Inclusion {
-                block: 1.into(),
-                max_block: None,
-            },
+            inclusion: Inclusion { block: 1.into(), max_block: None },
             bundle_body,
             validity,
             privacy,
@@ -420,7 +411,8 @@ mod tests {
             hash: true,
             tx_hash: true,
         };
-        let expected = r#"["calldata","contract_address","logs","function_selector","hash","tx_hash"]"#;
+        let expected =
+            r#"["calldata","contract_address","logs","function_selector","hash","tx_hash"]"#;
         let actual = serde_json::to_string(&hint).unwrap();
         assert_eq!(actual, expected);
     }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -16,7 +16,7 @@ tower = "0.4.13"
 
 ## eth 
 ethers-core.workspace = true
-ethers-signers = "2.0.7"
+ethers-signers.workspace = true
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,7 +12,11 @@ mev-share-rpc-api = { path = "../crates/mev-share-rpc-api", features = ["client"
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
 futures-util = { version = "0.3" }
 jsonrpsee = { version = "0.18", features = ["client", "async-client"] }
+tower = "0.4.13"
 
+## eth 
+ethers-core.workspace = true
+ethers-signers = "2.0.7"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["env-filter", "fmt"] }
 
 

--- a/examples/rpc-client.rs
+++ b/examples/rpc-client.rs
@@ -3,15 +3,15 @@
 use std::sync::Arc;
 
 use jsonrpsee::http_client::HttpClientBuilder;
-use mev_share_rpc_api::{FlashbotsSignerLayer, BundleItem, SendBundleRequest, MevApiClient};
-use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+use mev_share_rpc_api::{BundleItem, FlashbotsSignerLayer, MevApiClient, SendBundleRequest};
 use tower::ServiceBuilder;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-use ethers_core::{rand::thread_rng, types::{H256, TransactionRequest}};
+use ethers_core::{
+    rand::thread_rng,
+    types::{TransactionRequest, H256},
+};
 use ethers_signers::{LocalWallet, Signer};
-
-
-
 
 #[tokio::main]
 async fn main() {
@@ -24,10 +24,10 @@ async fn main() {
     let tx_signer = LocalWallet::new(&mut thread_rng());
 
     // Set up flashbots-style auth middleware
-    let signing_middleware = FlashbotsSignerLayer::new(Arc::new(fb_signer));
+    let signing_middleware = FlashbotsSignerLayer::new(fb_signer);
     let service_builder = ServiceBuilder::new().layer(signing_middleware);
 
-    // Set up the rpc client 
+    // Set up the rpc client
     let url = "https://relay.flashbots.net:443";
     let client = HttpClientBuilder::default()
         .set_middleware(service_builder)
@@ -45,18 +45,11 @@ async fn main() {
     // Build bundle
     let mut bundle_body = Vec::new();
     bundle_body.push(BundleItem::Hash { hash: tx_hash });
-    bundle_body.push(BundleItem::Tx {
-        tx: bytes,
-        can_revert: false,
-    });
+    bundle_body.push(BundleItem::Tx { tx: bytes, can_revert: false });
 
-    let bundle = SendBundleRequest {
-        bundle_body, 
-        ..Default::default()
-    };
+    let bundle = SendBundleRequest { bundle_body, ..Default::default() };
 
     // Send bundle
     let resp = client.send_bundle(bundle).await;
     println!("Got a bundle response: {:?}", resp);
-
 }

--- a/examples/rpc-client.rs
+++ b/examples/rpc-client.rs
@@ -2,7 +2,7 @@
 
 use jsonrpsee::http_client::{transport::Error as HttpError, HttpClientBuilder};
 use mev_share_rpc_api::{BundleItem, FlashbotsSignerLayer, MevApiClient, SendBundleRequest};
-use tower::{ServiceBuilder};
+use tower::ServiceBuilder;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 use ethers_core::{

--- a/examples/rpc-client.rs
+++ b/examples/rpc-client.rs
@@ -51,9 +51,8 @@ async fn main() {
     });
 
     let bundle = SendBundleRequest {
-        protocol_version: Default::default(),
-        inclusion_predicate: Default::default(),
-        bundle_body,
+        bundle_body, 
+        ..Default::default()
     };
 
     // Send bundle

--- a/examples/rpc-client.rs
+++ b/examples/rpc-client.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use jsonrpsee::http_client::HttpClientBuilder;
+use jsonrpsee::http_client::transport::Error as HttpError;
 use mev_share_rpc_api::{BundleItem, FlashbotsSignerLayer, MevApiClient, SendBundleRequest};
 use tower::ServiceBuilder;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
@@ -26,6 +27,9 @@ async fn main() {
     // Set up flashbots-style auth middleware
     let signing_middleware = FlashbotsSignerLayer::new(fb_signer);
     let service_builder = ServiceBuilder::new().layer(signing_middleware);
+
+    // Why does this not work? I should be able to map the error type from the auth middleware to the type expected by the http client builder
+    let service_builder = service_builder.map_err(|e| HttpError::Malformed);
 
     // Set up the rpc client
     let url = "https://relay.flashbots.net:443";

--- a/examples/rpc-client.rs
+++ b/examples/rpc-client.rs
@@ -1,13 +1,63 @@
-//! Basic SSE example
+//! Basic RPC api example
 
+use std::sync::Arc;
+
+use jsonrpsee::http_client::HttpClientBuilder;
+use mev_share_rpc_api::{FlashbotsSignerLayer, BundleItem, SendBundleRequest, MevApiClient};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+use tower::ServiceBuilder;
+
+use ethers_core::{rand::thread_rng, types::{H256, TransactionRequest}};
+use ethers_signers::{LocalWallet, Signer};
+
+
+
 
 #[tokio::main]
 async fn main() {
     tracing_subscriber::registry().with(fmt::layer()).with(EnvFilter::from_default_env()).init();
 
-    let url = "http://localhost:8545";
-    let _client = jsonrpsee::http_client::HttpClientBuilder::default()
+    // The signer used to authenticate bundles
+    let fb_signer = LocalWallet::new(&mut thread_rng());
+
+    // The signer used to sign our transactions
+    let tx_signer = LocalWallet::new(&mut thread_rng());
+
+    // Set up flashbots-style auth middleware
+    let signing_middleware = FlashbotsSignerLayer::new(Arc::new(fb_signer));
+    let service_builder = ServiceBuilder::new().layer(signing_middleware);
+
+    // Set up the rpc client 
+    let url = "https://relay.flashbots.net:443";
+    let client = HttpClientBuilder::default()
+        .set_middleware(service_builder)
         .build(url)
         .expect("Failed to create http client");
+
+    // Hash of the transaction we are trying to backrun
+    let tx_hash = H256::random();
+
+    // Our own tx that we want to include in the bundle
+    let tx = TransactionRequest::pay("vitalik.eth", 100);
+    let signature = tx_signer.sign_transaction(&tx.clone().into()).await.unwrap();
+    let bytes = tx.rlp_signed(&signature);
+
+    // Build bundle
+    let mut bundle_body = Vec::new();
+    bundle_body.push(BundleItem::TxHash { hash: tx_hash });
+    bundle_body.push(BundleItem::Tx {
+        tx: bytes,
+        can_revert: false,
+    });
+
+    let bundle = SendBundleRequest {
+        protocol_version: Default::default(),
+        inclusion_predicate: Default::default(),
+        bundle_body,
+    };
+
+    // Send bundle
+    let resp = client.send_bundle(bundle).await;
+    println!("Got a bundle response: {:?}", resp);
+
 }

--- a/examples/rpc-client.rs
+++ b/examples/rpc-client.rs
@@ -2,8 +2,7 @@
 
 use std::sync::Arc;
 
-use jsonrpsee::http_client::HttpClientBuilder;
-use jsonrpsee::http_client::transport::Error as HttpError;
+use jsonrpsee::http_client::{transport::Error as HttpError, HttpClientBuilder};
 use mev_share_rpc_api::{BundleItem, FlashbotsSignerLayer, MevApiClient, SendBundleRequest};
 use tower::{ServiceBuilder, ServiceExt};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};

--- a/examples/rpc-client.rs
+++ b/examples/rpc-client.rs
@@ -1,10 +1,8 @@
 //! Basic RPC api example
 
-use std::sync::Arc;
-
 use jsonrpsee::http_client::{transport::Error as HttpError, HttpClientBuilder};
 use mev_share_rpc_api::{BundleItem, FlashbotsSignerLayer, MevApiClient, SendBundleRequest};
-use tower::{ServiceBuilder, ServiceExt};
+use tower::{ServiceBuilder};
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 use ethers_core::{

--- a/examples/rpc-client.rs
+++ b/examples/rpc-client.rs
@@ -44,7 +44,7 @@ async fn main() {
 
     // Build bundle
     let mut bundle_body = Vec::new();
-    bundle_body.push(BundleItem::TxHash { hash: tx_hash });
+    bundle_body.push(BundleItem::Hash { hash: tx_hash });
     bundle_body.push(BundleItem::Tx {
         tx: bytes,
         can_revert: false,


### PR DESCRIPTION
Opening up a draft PR to discuss adding[ flashbots-style auth](https://docs.flashbots.net/flashbots-auction/searchers/advanced/rpc-endpoint#authentication) to the rpc client. This implementation is based on a tower middleware responsible for signing request bodies and adding the signature to a header. I've also added an example showing how to set up the rpc-client with signing middleware, and sending a request. 

A few questions: 

- should the http client with the signing middleware be abstracted into a separate "authed-client" implementation, or should we expect user to manually set up the signing middleware (like it's done in the example) whenever they want to use the client? 
- where should the layer implementation live? I've added it to a `auth.rs` file in the rpc-api crate, but not sure if this is right. 
- should the auth layer be an optional dependency behind a feature?
