### PR TITLE
feat: add MevApiExt trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1492,6 +1492,7 @@ dependencies = [
 name = "mev-share-rpc-api"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "ethers-core",
  "ethers-signers",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ hyper = "0.14"
 
 ## async
 futures-util = "0.3"
+async-trait = "0.1"
 
 ## misc
 serde_json = "1.0"

--- a/crates/mev-share-rpc-api/Cargo.toml
+++ b/crates/mev-share-rpc-api/Cargo.toml
@@ -23,6 +23,7 @@ http.workspace = true
 hyper = { workspace = true, features = ["stream"] }
 tower.workspace = true
 futures-util.workspace = true
+async-trait = "0.1"
 
 
 [dev-dependencies]

--- a/crates/mev-share-rpc-api/Cargo.toml
+++ b/crates/mev-share-rpc-api/Cargo.toml
@@ -23,7 +23,7 @@ http.workspace = true
 hyper = { workspace = true, features = ["stream"] }
 tower.workspace = true
 futures-util.workspace = true
-async-trait = "0.1"
+async-trait.workspace = true
 
 
 [dev-dependencies]

--- a/crates/mev-share-rpc-api/src/mev.rs
+++ b/crates/mev-share-rpc-api/src/mev.rs
@@ -1,6 +1,5 @@
-use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-
 use crate::{SendBundleRequest, SendBundleResponse, SimBundleOverrides, SimBundleResponse};
+use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 /// Mev rpc interface.
 #[cfg_attr(not(feature = "client"), rpc(server, namespace = "mev"))]
@@ -21,4 +20,58 @@ pub trait MevApi {
         bundle: SendBundleRequest,
         sim_overrides: SimBundleOverrides,
     ) -> RpcResult<SimBundleResponse>;
+}
+
+#[async_trait::async_trait]
+pub trait MevApiExt {
+    async fn send_bundle_request(
+        &self,
+        request: SendBundleRequest,
+    ) -> Result<SendBundleResponse, jsonrpsee::core::Error>;
+}
+
+#[async_trait::async_trait]
+impl<T> MevApiExt for T
+where
+    T: MevApiClient + Sync + Send,
+{
+    async fn send_bundle_request(
+        &self,
+        request: SendBundleRequest,
+    ) -> Result<SendBundleResponse, jsonrpsee::core::Error> {
+        self.send_bundle(request).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::FlashbotsSignerLayer;
+    use ethers_core::rand::thread_rng;
+    use ethers_signers::LocalWallet;
+    use jsonrpsee::http_client::{transport, HttpClient, HttpClientBuilder};
+
+    #[tokio::test]
+    async fn test_box() {
+        let fb_signer = LocalWallet::new(&mut thread_rng());
+
+        let http = HttpClientBuilder::default()
+            .set_middleware(
+                tower::ServiceBuilder::new()
+                    .map_err(transport::Error::Http)
+                    .layer(FlashbotsSignerLayer::new(fb_signer.clone())),
+            )
+            .build("http://localhost:3030")
+            .unwrap();
+        let b = Box::new(http) as Box<dyn MevApiExt>;
+        b.send_bundle_request(SendBundleRequest {
+            protocol_version: Default::default(),
+            inclusion: Default::default(),
+            bundle_body: vec![],
+            validity: None,
+            privacy: None,
+        })
+        .await
+        .unwrap();
+    }
 }

--- a/crates/mev-share-rpc-api/src/types.rs
+++ b/crates/mev-share-rpc-api/src/types.rs
@@ -511,6 +511,6 @@ mod tests {
           }
         "#;
         let actual: SimBundleResponse = serde_json::from_str(expected).unwrap();
-        assert_eq!(actual.success, true);
+        assert!(actual.success);
     }
 }


### PR DESCRIPTION
The generated json rpc client trait is not object safe which makes it hard to use.

this adds a separate trait with a blanket impl that can be boxed.

we could rename this and keep the generated private