### PR TITLE
feat: replace MevApiClient trait

### DIFF
--- a/crates/mev-share-rpc-api/src/eth.rs
+++ b/crates/mev-share-rpc-api/src/eth.rs
@@ -1,4 +1,4 @@
-use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use jsonrpsee::proc_macros::rpc;
 
 /// Eth bundle rpc interface.
 ///
@@ -10,20 +10,20 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 pub trait EthBundleApi {
     /// `eth_sendBundle` can be used to send your bundles to the builder.
     #[method(name = "sendBundle")]
-    async fn send_bundle(&self, request: ()) -> RpcResult<()>;
+    async fn send_bundle(&self, request: ()) -> jsonrpsee::core::RpcResult<()>;
 
     /// `eth_callBundle` can be used to simulate a bundle against a specific block number, including
     /// simulating a bundle at the top of the next block.
     #[method(name = "callBundle")]
-    async fn call_bundle(&self, request: ()) -> RpcResult<()>;
+    async fn call_bundle(&self, request: ()) -> jsonrpsee::core::RpcResult<()>;
 
     /// `eth_cancelBundle` is used to prevent a submitted bundle from being included on-chain. See [bundle cancellations](https://docs.flashbots.net/flashbots-auction/searchers/advanced/bundle-cancellations) for more information.
     #[method(name = "cancelBundle")]
-    async fn cancel_bundle(&self, request: ()) -> RpcResult<()>;
+    async fn cancel_bundle(&self, request: ()) -> jsonrpsee::core::RpcResult<()>;
 
     /// `eth_sendPrivateTransaction` is used to send a single transaction to Flashbots. Flashbots will attempt to build a block including the transaction for the next 25 blocks. See [Private Transactions](https://docs.flashbots.net/flashbots-auction/searchers/advanced/private-transaction) for more info.
     #[method(name = "sendPrivateTransaction")]
-    async fn send_private_transaction(&self, request: ()) -> RpcResult<()>;
+    async fn send_private_transaction(&self, request: ()) -> jsonrpsee::core::RpcResult<()>;
 
     /// The `eth_cancelPrivateTransaction` method stops private transactions from being submitted
     /// for future blocks.
@@ -31,5 +31,5 @@ pub trait EthBundleApi {
     /// A transaction can only be cancelled if the request is signed by the same key as the
     /// eth_sendPrivateTransaction call submitting the transaction in first place.
     #[method(name = "cancelPrivateTransaction")]
-    async fn cancel_private_transaction(&self, request: ()) -> RpcResult<()>;
+    async fn cancel_private_transaction(&self, request: ()) -> jsonrpsee::core::RpcResult<()>;
 }

--- a/crates/mev-share-rpc-api/src/lib.rs
+++ b/crates/mev-share-rpc-api/src/lib.rs
@@ -39,5 +39,9 @@ pub use clients::*;
 #[cfg(feature = "client")]
 #[doc(hidden)]
 pub mod clients {
-    pub use crate::{auth::FlashbotsSignerLayer, auth::FlashbotsSigner, eth::EthBundleApiClient, mev::MevApiClient};
+    pub use crate::{
+        auth::{FlashbotsSigner, FlashbotsSignerLayer},
+        eth::EthBundleApiClient,
+        mev::MevApiClient,
+    };
 }


### PR DESCRIPTION
as dicussed, hides the non object safe trait and replaces it with MevApiExt