### PR TITLE
feat(`deps`): Alloy primitives migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-primitives"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0628ec0ba5b98b3370bb6be17b12f23bfce8ee4ad83823325a20546d9b03b78"
+dependencies = [
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more",
+ "getrandom 0.2.10",
+ "hex-literal",
+ "itoa",
+ "rand 0.8.5",
+ "ruint",
+ "serde",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,10 +442,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c37be52ef5e3b394db27a2341010685ad5103c72ac15ce2e9420a7e8f93f342c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "hex",
+ "serde",
+]
+
+[[package]]
 name = "const-oid"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28c122c3980598d243d63d9a704629a2d748d101f278052ff068be5a4423ab6f"
+
+[[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
 name = "core-foundation"
@@ -521,8 +558,10 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn 1.0.109",
 ]
 
@@ -912,6 +951,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 name = "examples"
 version = "0.0.0"
 dependencies = [
+ "alloy-primitives",
  "anyhow",
  "ethers-core",
  "ethers-middleware",
@@ -1300,6 +1340,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
@@ -1732,6 +1781,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
+name = "libm"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,6 +1847,7 @@ dependencies = [
 name = "mev-share-rpc-api"
 version = "0.1.4"
 dependencies = [
+ "alloy-primitives",
  "async-trait",
  "ethers-core",
  "ethers-signers",
@@ -1809,6 +1865,7 @@ dependencies = [
 name = "mev-share-sse"
 version = "0.1.4"
 dependencies = [
+ "alloy-primitives",
  "async-sse",
  "bytes",
  "ethers-core",
@@ -1880,6 +1937,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2215,6 +2273,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c003ac8c77cb07bb74f5f198bce836a689bcd5a42574612bf14d17bfd08c20e"
+dependencies = [
+ "bitflags 2.4.0",
+ "num-traits",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "unarray",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2304,6 +2376,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2464,6 +2545,26 @@ name = "route-recognizer"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
+
+[[package]]
+name = "ruint"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95294d6e3a6192f3aabf91c38f56505a625aa495533442744185a36d75a790c4"
+dependencies = [
+ "proptest",
+ "rand 0.8.5",
+ "ruint-macro",
+ "serde",
+ "valuable",
+ "zeroize",
+]
+
+[[package]]
+name = "ruint-macro"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e666a5496a0b2186dbcd0ff6106e29e093c15591bde62c20d3842007c6978a09"
 
 [[package]]
 name = "rustc-demangle"
@@ -3309,6 +3410,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3368,6 +3475,12 @@ dependencies = [
  "getrandom 0.2.10",
  "serde",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1868,7 +1868,6 @@ dependencies = [
  "alloy-primitives",
  "async-sse",
  "bytes",
- "ethers-core",
  "futures-util",
  "http",
  "http-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,8 @@ ethers-core = { version = "2.0", default-features = false }
 ethers-signers = "2.0"
 ethers-providers = "2.0"
 
+alloy-primitives = { version = "0.4", default-features = false}
+
 ## net
 http = "0.2.9"
 tower = "0.4"

--- a/crates/mev-share-backend/src/lib.rs
+++ b/crates/mev-share-backend/src/lib.rs
@@ -60,17 +60,17 @@ impl SimulatedBundle {
 
     /// Returns the profit of the simulation.
     pub fn profit(&self) -> u64 {
-        self.response.profit.as_u64()
+        self.response.profit.to::<u64>()
     }
 
     /// Returns the gas used by the simulation.
     pub fn gas_used(&self) -> u64 {
-        self.response.gas_used.as_u64()
+        self.response.gas_used.to::<u64>()
     }
 
     /// Returns the mev gas price of the simulation.
     pub fn mev_gas_price(&self) -> u64 {
-        self.response.mev_gas_price.as_u64()
+        self.response.mev_gas_price.to::<u64>()
     }
 
     ///

--- a/crates/mev-share-rpc-api/Cargo.toml
+++ b/crates/mev-share-rpc-api/Cargo.toml
@@ -16,6 +16,8 @@ MEV-share RPC API trait definitions
 ethers-core.workspace = true
 ethers-signers.workspace = true
 
+alloy-primitives = {workspace = true, features = ["serde"] }
+
 ## misc
 jsonrpsee = { workspace = true, features = ["server", "macros"] }
 serde.workspace = true

--- a/crates/mev-share-rpc-api/src/auth.rs
+++ b/crates/mev-share-rpc-api/src/auth.rs
@@ -7,7 +7,7 @@ use std::{
     task::{Context, Poll},
 };
 
-use ethers_core::{types::H256, utils::keccak256};
+use alloy_primitives::{keccak256, B256};
 use ethers_signers::Signer;
 use futures_util::future::BoxFuture;
 
@@ -98,7 +98,7 @@ where
 
             // sign request body and insert header
             let signature = signer
-                .sign_message(format!("0x{:x}", H256::from(keccak256(body_bytes.as_ref()))))
+                .sign_message(format!("0x{:x}", B256::from(keccak256(body_bytes.as_ref()))))
                 .await?;
 
             let header_val =
@@ -159,7 +159,7 @@ mod tests {
 
         let signer_address = format!("{:?}", fb_signer.address());
         let expected_signature = fb_signer
-            .sign_message(format!("0x{:x}", H256::from(keccak256(bytes.clone()))))
+            .sign_message(format!("0x{:x}", B256::from(keccak256(bytes.clone()))))
             .await
             .unwrap()
             .to_string();

--- a/crates/mev-share-rpc-api/src/eth.rs
+++ b/crates/mev-share-rpc-api/src/eth.rs
@@ -2,7 +2,7 @@ use crate::{
     CancelBundleRequest, CancelPrivateTransactionRequest, EthBundleHash, EthCallBundleResponse,
     EthCallBundleTransactionResult, EthSendBundle, PrivateTransactionRequest,
 };
-use ethers_core::types::{Bytes, H256};
+use alloy_primitives::{Bytes, B256};
 
 // re-export the rpc server trait
 #[cfg(feature = "server")]
@@ -16,7 +16,7 @@ mod rpc {
         CancelBundleRequest, CancelPrivateTransactionRequest, EthBundleHash, EthCallBundleResponse,
         EthCallBundleTransactionResult, EthSendBundle, PrivateTransactionRequest,
     };
-    use ethers_core::types::{Bytes, H256};
+    use alloy_primitives::{Bytes, B256};
     use jsonrpsee::proc_macros::rpc;
 
     /// Eth bundle rpc interface.
@@ -54,7 +54,7 @@ mod rpc {
         async fn send_private_transaction(
             &self,
             request: PrivateTransactionRequest,
-        ) -> jsonrpsee::core::RpcResult<H256>;
+        ) -> jsonrpsee::core::RpcResult<B256>;
 
         /// The `eth_sendPrivateRawTransaction` method can be used to send private transactions to
         /// the RPC endpoint. Private transactions are protected from frontrunning and kept
@@ -64,7 +64,7 @@ mod rpc {
         async fn send_private_raw_transaction(
             &self,
             bytes: Bytes,
-        ) -> jsonrpsee::core::RpcResult<H256>;
+        ) -> jsonrpsee::core::RpcResult<B256>;
 
         /// The `eth_cancelPrivateTransaction` method stops private transactions from being
         /// submitted for future blocks.
@@ -106,7 +106,7 @@ pub trait EthBundleApiClient {
     async fn send_private_transaction(
         &self,
         request: PrivateTransactionRequest,
-    ) -> Result<H256, jsonrpsee::core::Error>;
+    ) -> Result<B256, jsonrpsee::core::Error>;
 
     /// The `eth_sendPrivateRawTransaction` method can be used to send private transactions to the
     /// RPC endpoint. Private transactions are protected from frontrunning and kept private until
@@ -115,7 +115,7 @@ pub trait EthBundleApiClient {
     async fn send_private_raw_transaction(
         &self,
         bytes: Bytes,
-    ) -> Result<H256, jsonrpsee::core::Error>;
+    ) -> Result<B256, jsonrpsee::core::Error>;
 
     /// The `eth_cancelPrivateTransaction` method stops private transactions from being submitted
     /// for future blocks.
@@ -158,14 +158,14 @@ where
     async fn send_private_transaction(
         &self,
         request: PrivateTransactionRequest,
-    ) -> Result<H256, jsonrpsee::core::Error> {
+    ) -> Result<B256, jsonrpsee::core::Error> {
         rpc::EthBundleApiClient::send_private_transaction(self, request).await
     }
 
     async fn send_private_raw_transaction(
         &self,
         bytes: Bytes,
-    ) -> Result<H256, jsonrpsee::core::Error> {
+    ) -> Result<B256, jsonrpsee::core::Error> {
         rpc::EthBundleApiClient::send_private_raw_transaction(self, bytes).await
     }
 

--- a/crates/mev-share-rpc-api/src/flashbots.rs
+++ b/crates/mev-share-rpc-api/src/flashbots.rs
@@ -1,5 +1,5 @@
 use crate::{BundleStats, UserStats};
-use ethers_core::types::{H256, U64};
+use alloy_primitives::{B256, U64};
 
 // re-export the rpc server trait
 #[cfg(feature = "server")]
@@ -13,7 +13,7 @@ pub use rpc::FlashbotsApiServer;
 /// [jsonrpsee_proc_macros]: https://docs.rs/jsonrpsee-proc-macros/0.20.0/jsonrpsee_proc_macros/attr.rpc.html
 mod rpc {
     use crate::{BundleStats, UserStats};
-    use ethers_core::types::{H256, U64};
+    use alloy_primitives::{B256, U64};
     use jsonrpsee::proc_macros::rpc;
     use serde::{Deserialize, Serialize};
 
@@ -27,7 +27,7 @@ mod rpc {
     #[serde(rename_all = "camelCase")]
 
     pub struct GetBundleStatsRequest {
-        pub bundle_hash: H256,
+        pub bundle_hash: B256,
         pub block_number: U64,
     }
 
@@ -83,7 +83,7 @@ pub trait FlashbotsApiClient {
     /// * `block_number` - The block number the bundle was targeting. See [`crate::Inclusion`].
     async fn get_bundle_stats(
         &self,
-        bundle_hash: H256,
+        bundle_hash: B256,
         block_number: U64,
     ) -> Result<BundleStats, jsonrpsee::core::Error>;
 }
@@ -102,7 +102,7 @@ where
     /// See [`FlashbotsApiClient::get_user_stats`]
     async fn get_bundle_stats(
         &self,
-        bundle_hash: H256,
+        bundle_hash: B256,
         block_number: U64,
     ) -> Result<BundleStats, jsonrpsee::core::Error> {
         self.get_bundle_stats(rpc::GetBundleStatsRequest { bundle_hash, block_number }).await

--- a/crates/mev-share-rpc-api/src/types.rs
+++ b/crates/mev-share-rpc-api/src/types.rs
@@ -1,6 +1,7 @@
 //! MEV-share bundle type bindings
 #![allow(missing_docs)]
-use ethers_core::types::{Address, BlockId, BlockNumber, Bytes, Log, TxHash, H256, U256, U64};
+use alloy_primitives::{Address, Bytes, TxHash, B256, U256, U64};
+use ethers_core::types::{BlockId, BlockNumber, Log};
 use serde::{
     ser::{SerializeSeq, Serializer},
     Deserialize, Deserializer, Serialize,
@@ -49,13 +50,13 @@ impl Inclusion {
     /// Returns the block number of the first block the bundle is valid for.
     #[inline]
     pub fn block_number(&self) -> u64 {
-        self.block.as_u64()
+        self.block.to::<u64>()
     }
 
     /// Returns the block number of the last block the bundle is valid for.
     #[inline]
     pub fn max_block_number(&self) -> Option<u64> {
-        self.max_block.as_ref().map(|b| b.as_u64())
+        self.max_block.as_ref().map(|b| b.to::<u64>())
     }
 }
 
@@ -272,7 +273,7 @@ impl<'de> Deserialize<'de> for PrivacyHint {
 #[serde(rename_all = "camelCase")]
 pub struct SendBundleResponse {
     /// Hash of the bundle bodies.
-    pub bundle_hash: H256,
+    pub bundle_hash: B256,
 }
 
 /// The version of the MEV-share API to use.
@@ -415,7 +416,7 @@ impl PrivateTransactionPreferences {
 #[serde(rename_all = "camelCase")]
 pub struct CancelPrivateTransactionRequest {
     /// Transaction hash of the transaction to be canceled
-    pub tx_hash: H256,
+    pub tx_hash: B256,
 }
 
 // TODO(@optimiz-r): Revisit after <https://github.com/flashbots/flashbots-docs/issues/424> is closed.
@@ -577,7 +578,7 @@ pub struct EthSendBundle {
     pub max_timestamp: Option<u64>,
     /// list of hashes of possibly reverting txs
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub reverting_tx_hashes: Vec<H256>,
+    pub reverting_tx_hashes: Vec<B256>,
     /// UUID that can be used to cancel/replace this bundle
     #[serde(rename = "replacementUuid", skip_serializing_if = "Option::is_none")]
     pub replacement_uuid: Option<String>,
@@ -588,7 +589,7 @@ pub struct EthSendBundle {
 #[serde(rename_all = "camelCase")]
 pub struct EthBundleHash {
     /// Hash of the bundle bodies.
-    pub bundle_hash: H256,
+    pub bundle_hash: B256,
 }
 
 /// Bundle of transactions for `eth_callBundle`
@@ -641,7 +642,7 @@ pub struct EthCallBundleTransactionResult {
     pub gas_price: U256,
     pub gas_used: u64,
     pub to_address: Address,
-    pub tx_hash: H256,
+    pub tx_hash: B256,
     pub value: Bytes,
 }
 

--- a/crates/mev-share-sse/Cargo.toml
+++ b/crates/mev-share-sse/Cargo.toml
@@ -11,7 +11,6 @@ MEV-share Server Side Events support in rust
 """
 
 [dependencies]
-ethers-core.workspace = true
 alloy-primitives = { workspace = true, features = ["serde"] }
 
 ## async

--- a/crates/mev-share-sse/Cargo.toml
+++ b/crates/mev-share-sse/Cargo.toml
@@ -12,6 +12,7 @@ MEV-share Server Side Events support in rust
 
 [dependencies]
 ethers-core.workspace = true
+alloy-primitives = { workspace = true, features = ["serde"] }
 
 ## async
 async-sse = "5.1"

--- a/crates/mev-share-sse/src/types.rs
+++ b/crates/mev-share-sse/src/types.rs
@@ -1,10 +1,6 @@
 //! MEV-share event type bindings
 
-use ethers_core::{
-    abi::Address,
-    types::{Bytes, TxHash, H256, U256},
-    utils::hex,
-};
+use alloy_primitives::{hex, Address, Bytes, TxHash, B256, U256};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{array::TryFromSliceError, fmt::LowerHex, ops::Deref};
 
@@ -48,7 +44,7 @@ pub struct EventTransactionLog {
     /// (In solidity: The first topic is the hash of the signature of the event
     /// (e.g. `Deposit(address,bytes32,uint256)`), except you declared the event
     /// with the anonymous specifier.)
-    pub topics: Vec<H256>,
+    pub topics: Vec<B256>,
     /// The data of the log
     pub data: Bytes,
 }
@@ -84,7 +80,7 @@ pub struct EventHistory {
 pub struct Hint {
     #[serde(with = "null_sequence")]
     pub txs: Vec<EventTransaction>,
-    pub hash: H256,
+    pub hash: B256,
     #[serde(with = "null_sequence")]
     pub logs: Vec<EventTransactionLog>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -24,6 +24,8 @@ ethers-providers.workspace = true
 ethers-signers.workspace = true
 ethers-middleware = "2.0"
 
+alloy-primitives = { workspace = true, features = ["serde", "rand"] }
+
 ## server
 hyper = { workspace = true, features = ["full"] }
 

--- a/examples/rpc-client-onchain.rs
+++ b/examples/rpc-client-onchain.rs
@@ -124,7 +124,7 @@ async fn main() -> Result<()> {
     let bundle_request = SendBundleRequest {
         protocol_version: mev_share_rpc_api::ProtocolVersion::V0_1,
         bundle_body,
-        inclusion: Inclusion { block: target_block, ..Default::default() },
+        inclusion: Inclusion { block: U64::from_limbs(target_block.0), ..Default::default() },
         ..Default::default()
     };
 
@@ -137,7 +137,8 @@ async fn main() -> Result<()> {
     tokio::time::sleep(wait_duration).await;
 
     // Get bundle stats
-    let bundle_stats = client.get_bundle_stats(B256::random(), target_block).await;
+    let bundle_stats =
+        client.get_bundle_stats(B256::random(), U64::from_limbs(target_block.0)).await;
     println!("`flashbots_getBundleStatsV2`: {:?}", bundle_stats);
 
     // Get user stats

--- a/examples/rpc-client-onchain.rs
+++ b/examples/rpc-client-onchain.rs
@@ -1,11 +1,10 @@
 //! Basic RPC api example
 
+use alloy_primitives::{Bytes, B256, U64};
 use anyhow::Result;
 use ethers_core::{
     rand::thread_rng,
-    types::{
-        transaction::eip2718::TypedTransaction, Bytes, Chain, Eip1559TransactionRequest, H256,
-    },
+    types::{transaction::eip2718::TypedTransaction, Chain, Eip1559TransactionRequest},
 };
 use ethers_middleware::MiddlewareBuilder;
 use ethers_providers::{Middleware, Provider};
@@ -138,11 +137,11 @@ async fn main() -> Result<()> {
     tokio::time::sleep(wait_duration).await;
 
     // Get bundle stats
-    let bundle_stats = client.get_bundle_stats(H256::random(), target_block).await;
+    let bundle_stats = client.get_bundle_stats(B256::random(), target_block).await;
     println!("`flashbots_getBundleStatsV2`: {:?}", bundle_stats);
 
     // Get user stats
-    let user_stats = client.get_user_stats(current_block).await;
+    let user_stats = client.get_user_stats(U64::from(current_block.as_u64())).await;
     println!("`flashbots_getUserStatsV2`: {:?}", user_stats);
 
     Ok(())
@@ -181,6 +180,6 @@ impl TxSign for TypedTransaction {
         S::Error: 'static,
     {
         let signature = signer.sign_transaction(self).await?;
-        Ok(self.rlp_signed(&signature))
+        Ok(self.rlp_signed(&signature).0.into())
     }
 }

--- a/examples/rpc-client.rs
+++ b/examples/rpc-client.rs
@@ -7,10 +7,8 @@ use mev_share_rpc_api::{
 use tower::ServiceBuilder;
 use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
-use ethers_core::{
-    rand::thread_rng,
-    types::{TransactionRequest, H256},
-};
+use alloy_primitives::B256;
+use ethers_core::{rand::thread_rng, types::TransactionRequest};
 use ethers_signers::{LocalWallet, Signer};
 
 #[tokio::main]
@@ -38,7 +36,7 @@ async fn main() {
         .expect("Failed to create http client");
 
     // Hash of the transaction we are trying to backrun
-    let tx_hash = H256::random();
+    let tx_hash = B256::random();
 
     // Our own tx that we want to include in the bundle
     let tx = TransactionRequest::pay("vitalik.eth", 100);

--- a/examples/rpc-client.rs
+++ b/examples/rpc-client.rs
@@ -44,8 +44,10 @@ async fn main() {
     let bytes = tx.rlp_signed(&signature);
 
     // Build bundle
-    let bundle_body =
-        vec![BundleItem::Hash { hash: tx_hash }, BundleItem::Tx { tx: bytes, can_revert: false }];
+    let bundle_body = vec![
+        BundleItem::Hash { hash: tx_hash },
+        BundleItem::Tx { tx: bytes.0.into(), can_revert: false },
+    ];
 
     let bundle = SendBundleRequest { bundle_body, ..Default::default() };
 

--- a/examples/sse-server.rs
+++ b/examples/sse-server.rs
@@ -1,5 +1,5 @@
 //! SSE server example
-use ethers_core::types::H256;
+use alloy_primitives::B256;
 use futures_util::StreamExt;
 use hyper::{service::make_service_fn, Server};
 use mev_share_sse::{Event, EventClient};
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>
         }
     });
 
-    let event = Event { hash: H256::random(), transactions: vec![], logs: vec![] };
+    let event = Event { hash: B256::random(), transactions: vec![], logs: vec![] };
 
     broadcaster.send(&event).unwrap();
 


### PR DESCRIPTION
Closes #37, albeit ethers still remains due to provider usage.

Migrates all primitive types to use alloy. Wonder if we should include optional conversion types meanwhile alloy providers is still not integrated?