### PR TITLE
Update builders to vector of strings in privacy struct

### DIFF
--- a/crates/mev-share-rpc-api/src/types.rs
+++ b/crates/mev-share-rpc-api/src/types.rs
@@ -122,9 +122,10 @@ pub struct Privacy {
     /// Hints on what data should be shared about the bundle and its transactions
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hints: Option<PrivacyHint>,
-    /// The addresses of the builders that should be allowed to see the bundle/transaction.
+    /// Names of the builders that should be allowed to see the bundle/transaction.
+    /// https://github.com/flashbots/dowg/blob/main/builder-registrations.json
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub builders: Option<Vec<Address>>,
+    pub builders: Option<Vec<String>>,
 }
 
 /// Hints on what data should be shared about the bundle and its transactions


### PR DESCRIPTION
According to mev-share [specification](https://github.com/flashbots/mev-share/blob/09d9ea87d4f907aa69ffd914802209ae8ea680a4/specs/bundles/v0.1.md#privacy) builders are specified by their names which you can find on this page

https://github.com/flashbots/dowg/blob/main/builder-registrations.json